### PR TITLE
Switch from black to ruff format

### DIFF
--- a/.github/bump_version.py
+++ b/.github/bump_version.py
@@ -19,9 +19,7 @@ def get_current_version(pyproject_path: Path) -> str:
 
 def infer_bump(changelog_dir: Path) -> str:
     fragments = [
-        f
-        for f in changelog_dir.iterdir()
-        if f.is_file() and f.name != ".gitkeep"
+        f for f in changelog_dir.iterdir() if f.is_file() and f.name != ".gitkeep"
     ]
     if not fragments:
         print("No changelog fragments found", file=sys.stderr)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,15 +24,11 @@ jobs:
       
       - name: Install dependencies
         run: |
-          uv pip install --system black linecheck
-      
-      - name: Check formatting with Black
+          uv pip install --system ruff
+
+      - name: Check formatting with ruff
         run: |
-          black . -l 79 --check
-      
-      - name: Run linecheck
-        run: |
-          linecheck . --check
+          ruff format --check .
 
   test:
     name: Test

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -28,8 +28,7 @@ jobs:
       
       - name: Check formatting
         run: |
-          black . -l 79 --check
-          linecheck . --check
+          ruff format --check .
       
       - name: Run tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ documentation:
 	myst build docs -o docs/_build
 
 format:
-	black . -l 79
-	linecheck . --fix
+	ruff format .
 
 install:
 	uv pip install --system -e .[dev]

--- a/changelog.d/switch-to-ruff.changed.md
+++ b/changelog.d/switch-to-ruff.changed.md
@@ -1,0 +1,1 @@
+Switch from black to ruff format.

--- a/policyengine_au/tests/conftest.py
+++ b/policyengine_au/tests/conftest.py
@@ -65,13 +65,13 @@ class YamlTestItem(pytest.Item):
 
                 # Allow small tolerance for floating point comparisons
                 if isinstance(expected_value, (int, float)):
-                    assert (
-                        abs(calculated - expected_value) < 0.01
-                    ), f"{variable_name}: expected {expected_value}, got {calculated}"
+                    assert abs(calculated - expected_value) < 0.01, (
+                        f"{variable_name}: expected {expected_value}, got {calculated}"
+                    )
                 else:
-                    assert (
-                        calculated == expected_value
-                    ), f"{variable_name}: expected {expected_value}, got {calculated}"
+                    assert calculated == expected_value, (
+                        f"{variable_name}: expected {expected_value}, got {calculated}"
+                    )
 
     def reportinfo(self):
         """Report test location."""

--- a/policyengine_au/tests/test_system.py
+++ b/policyengine_au/tests/test_system.py
@@ -28,9 +28,9 @@ def test_entities_loaded():
     entity_keys = {entity.key for entity in system.entities}
 
     for entity_name in expected_entities:
-        assert (
-            entity_name in entity_keys
-        ), f"Entity {entity_name} not found in {entity_keys}"
+        assert entity_name in entity_keys, (
+            f"Entity {entity_name} not found in {entity_keys}"
+        )
 
     # Check that person_entity is accessible (main entity)
     assert system.person_entity is not None
@@ -52,10 +52,7 @@ def test_parameters_loaded():
     p_2024 = parameters(period)
 
     # Test income tax parameters
-    assert (
-        p_2024.gov.ato.income_tax.thresholds.thresholds.tax_free_threshold
-        == 18_200
-    )
+    assert p_2024.gov.ato.income_tax.thresholds.thresholds.tax_free_threshold == 18_200
     assert p_2024.gov.ato.income_tax.rates.rates.bracket_2 == 0.19
 
     # Test Medicare levy

--- a/policyengine_au/variables/gov/ato/medicare/medicare_levy.py
+++ b/policyengine_au/variables/gov/ato/medicare/medicare_levy.py
@@ -8,9 +8,7 @@ class medicare_levy(Variable):
     entity = Person
     definition_period = YEAR
     label = "Medicare levy"
-    documentation = (
-        "Medicare levy based on taxable income and family circumstances"
-    )
+    documentation = "Medicare levy based on taxable income and family circumstances"
     reference = "https://www.ato.gov.au/individuals-and-families/medicare-and-private-health-insurance/medicare-levy"
     unit = AUD
 

--- a/policyengine_au/variables/gov/states/nsw/payroll_tax.py
+++ b/policyengine_au/variables/gov/states/nsw/payroll_tax.py
@@ -7,7 +7,9 @@ class nsw_payroll_tax(Variable):
     label = "NSW payroll tax"
     definition_period = YEAR
     unit = "AUD"
-    reference = "https://www.legislation.nsw.gov.au/view/html/inforce/current/act-2007-021"
+    reference = (
+        "https://www.legislation.nsw.gov.au/view/html/inforce/current/act-2007-021"
+    )
 
     def formula(household, period, parameters):
         # Get NSW payroll tax parameters

--- a/policyengine_au/variables/gov/states/nt/payroll_tax.py
+++ b/policyengine_au/variables/gov/states/nt/payroll_tax.py
@@ -7,9 +7,7 @@ class nt_payroll_tax(Variable):
     label = "NT payroll tax"
     definition_period = YEAR
     unit = "AUD"
-    reference = (
-        "https://legislation.nt.gov.au/en/Legislation/PAYROLL-TAX-ACT-2009"
-    )
+    reference = "https://legislation.nt.gov.au/en/Legislation/PAYROLL-TAX-ACT-2009"
 
     def formula(household, period, parameters):
         # Get NT payroll tax parameters

--- a/policyengine_au/variables/gov/states/qld/payroll_tax.py
+++ b/policyengine_au/variables/gov/states/qld/payroll_tax.py
@@ -7,7 +7,9 @@ class qld_payroll_tax(Variable):
     label = "QLD payroll tax"
     definition_period = YEAR
     unit = "AUD"
-    reference = "https://www.legislation.qld.gov.au/view/html/inforce/current/act-1971-062"
+    reference = (
+        "https://www.legislation.qld.gov.au/view/html/inforce/current/act-1971-062"
+    )
 
     def formula(household, period, parameters):
         # Get QLD payroll tax parameters

--- a/policyengine_au/variables/gov/states/sa/payroll_tax.py
+++ b/policyengine_au/variables/gov/states/sa/payroll_tax.py
@@ -7,7 +7,9 @@ class sa_payroll_tax(Variable):
     label = "SA payroll tax"
     definition_period = YEAR
     unit = "AUD"
-    reference = "https://www.legislation.sa.gov.au/LZ/C/A/Payroll%20Tax%20Act%202009.aspx"
+    reference = (
+        "https://www.legislation.sa.gov.au/LZ/C/A/Payroll%20Tax%20Act%202009.aspx"
+    )
 
     def formula(household, period, parameters):
         # Get SA payroll tax parameters

--- a/policyengine_au/variables/gov/states/tas/payroll_tax.py
+++ b/policyengine_au/variables/gov/states/tas/payroll_tax.py
@@ -7,7 +7,9 @@ class tas_payroll_tax(Variable):
     label = "TAS payroll tax"
     definition_period = YEAR
     unit = "AUD"
-    reference = "https://www.legislation.tas.gov.au/view/html/inforce/current/act-2008-016"
+    reference = (
+        "https://www.legislation.tas.gov.au/view/html/inforce/current/act-2008-016"
+    )
 
     def formula(household, period, parameters):
         # Get TAS payroll tax parameters

--- a/policyengine_au/variables/gov/states/vic/payroll_tax.py
+++ b/policyengine_au/variables/gov/states/vic/payroll_tax.py
@@ -7,9 +7,7 @@ class vic_payroll_tax(Variable):
     label = "VIC payroll tax"
     definition_period = YEAR
     unit = "AUD"
-    reference = (
-        "https://www.legislation.vic.gov.au/in-force/acts/payroll-tax-act-2007"
-    )
+    reference = "https://www.legislation.vic.gov.au/in-force/acts/payroll-tax-act-2007"
 
     def formula(household, period, parameters):
         # Get VIC payroll tax parameters

--- a/policyengine_au/variables/gov/states/wa/payroll_tax.py
+++ b/policyengine_au/variables/gov/states/wa/payroll_tax.py
@@ -24,8 +24,7 @@ class wa_payroll_tax(Variable):
 
         # Vectorized threshold calculation
         reduction = (
-            clip(wages - lower_limit, 0, upper_limit - lower_limit)
-            * reduction_rate
+            clip(wages - lower_limit, 0, upper_limit - lower_limit) * reduction_rate
         )
         effective_threshold = select(
             [wages <= lower_limit, wages <= upper_limit],

--- a/policyengine_au/variables/input/demographics/household_state.py
+++ b/policyengine_au/variables/input/demographics/household_state.py
@@ -17,6 +17,4 @@ class household_state(Variable):
 
     def formula(household, period, parameters):
         # Use the state of the household head (first person)
-        return household.value_from_first_person(
-            household.members("state", period)
-        )
+        return household.value_from_first_person(household.members("state", period))

--- a/policyengine_au/variables/input/demographics/state.py
+++ b/policyengine_au/variables/input/demographics/state.py
@@ -23,7 +23,5 @@ class state(Variable):
     entity = Person
     definition_period = YEAR
     label = "State or territory of residence"
-    documentation = (
-        "The Australian state or territory where the person resides"
-    )
+    documentation = "The Australian state or territory where the person resides"
     reference = "https://www.abs.gov.au/statistics/standards/australian-statistical-geography-standard-asgs-edition-3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,7 @@ dependencies = [
 dev = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
-    "black>=24.8.0",
-    "linecheck>=0.1.0",
+    "ruff>=0.9.0",
     "jupyter-book>=1.0.4",
     "mystmd>=1.3.17",
     "wheel>=0.38.4",
@@ -63,10 +62,6 @@ Homepage = "https://policyengine.org"
 Repository = "https://github.com/PolicyEngine/policyengine-au"
 Documentation = "https://policyengine.org/au/api"
 Tracker = "https://github.com/PolicyEngine/policyengine-au/issues"
-
-[tool.black]
-line-length = 79
-target-version = ["py310", "py311", "py312", "py313"]
 
 [tool.pytest.ini_options]
 testpaths = ["policyengine_au/tests"]


### PR DESCRIPTION
## Summary
- Replace black and linecheck with ruff>=0.9.0 in dev dependencies
- Update Makefile and CI workflows (pr.yaml, push.yaml) to use `ruff format` instead of `black` and `linecheck`
- Remove `[tool.black]` section from pyproject.toml
- Reformat all files with ruff defaults (88 char line length)

## Test plan
- [x] `ruff format --check .` passes
- [ ] CI checks pass

Generated with [Claude Code](https://claude.com/claude-code)